### PR TITLE
[3441] - allow cvc to be optional on attempt-payment endpoint (note: MOTO only)

### DIFF
--- a/ryft_sdk/models/payment_sessions/req/payment_sessions_req.py
+++ b/ryft_sdk/models/payment_sessions/req/payment_sessions_req.py
@@ -118,7 +118,7 @@ class CardDetailsRequest(TypedDict):
     number: str
     expiryMonth: str
     expiryYear: str
-    cvc: str
+    cvc: NotRequired[str]
     name: NotRequired[str]
 
 


### PR DESCRIPTION
This change allows the `cvc` parameter to now be optional.
Note that is is currently only applicable to MOTO payments