### PR TITLE
RP-675: Add ShippingDetails to ContinuePayment Response

### DIFF
--- a/ryft_sdk/models/shipping_details.py
+++ b/ryft_sdk/models/shipping_details.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 from ryft_sdk.models.address import Address
 
 
 class ShippingDetails(TypedDict):
     address: Address
+    phoneNumber: NotRequired[str]

--- a/test/payment_sessions/mock_data/mock_payment_sessions_resp.py
+++ b/test/payment_sessions/mock_data/mock_payment_sessions_resp.py
@@ -91,7 +91,8 @@ def mock_payment_session_resp():
                 "postalCode": "SP4 7DE",
                 "city": "Salisbury",
                 "country": "GB",
-            }
+            },
+            "phoneNumber": "+447900000000",
         },
         "orderDetails": {
             "items": [

--- a/test/payment_sessions/mock_data/mock_payment_sessions_txs_resp.py
+++ b/test/payment_sessions/mock_data/mock_payment_sessions_txs_resp.py
@@ -82,7 +82,8 @@ def mock_payment_sessions_txs_resp():
                 "postalCode": "SP4 7DE",
                 "city": "Salisbury",
                 "country": "GB",
-            }
+            },
+            "phoneNumber": "+447900000000",
         },
         "orderDetails": {
             "items": [


### PR DESCRIPTION
- The shippingDetails model is already defined but is lacking the optional phone number field. Adding that to align.